### PR TITLE
Remove margin around video

### DIFF
--- a/src/QrScan.css
+++ b/src/QrScan.css
@@ -1,6 +1,5 @@
 .qr {
   video {
     border: 2px solid rgb(200, 200, 200);
-    margin: 1.5em auto;
   }
 }


### PR DESCRIPTION
cf https://github.com/paritytech/fether/pull/336#issuecomment-452019185

![image](https://user-images.githubusercontent.com/5739676/51028122-e8674000-1592-11e9-8094-e4a7d590167c.png)

The margin styling creates a bar to the left of the video. Might have to do with box styling. Removing the styling fixes the problem.

I cannot override the margin in Fether because the `margin: 1.5em auto;` line doesn't show somehow, although it still affects the rendering.